### PR TITLE
Fix for broken subscribe method in Ruby library

### DIFF
--- a/client/lib/juggernaut.rb
+++ b/client/lib/juggernaut.rb
@@ -12,7 +12,7 @@ module Juggernaut
   end
   
   def subscribe
-    Redis.new(redis_options).subscribe("juggernaut:*") do |on|
+    Redis.new(redis_options).subscribe("juggernaut:subscribe", "juggernaut:unsubscribe") do |on|
       on.message do |type, msg|
         yield(type.gsub(/^juggernaut:/, "").to_sym, JSON.parse(msg))
       end


### PR DESCRIPTION
The code in "client/examples/roster.rb" isn't working.  The redis library doesn't support the wildcard pattern when using SUBSCRIBE.  To use wildcards I believe you have to use PSUBSCRIBE (and then handle the PMESSAGE callback).

I expanded the "juggernaut:*" wildcard pattern to "juggernaut:subscribe" & "juggernaut"unsubscribe" and now the example is working.

Thanks!
