### PR TITLE
Redis replace

### DIFF
--- a/lib/juggernaut/publish.js
+++ b/lib/juggernaut/publish.js
@@ -6,7 +6,7 @@ var Channel = require("./channel");
 Publish = module.exports = {};
 Publish.listen = function(){
   this.client = redis.createClient();
-  this.client.subscribeTo("juggernaut", function(_, data) {
+  this.client.subscribe("juggernaut", function(_, data) {
     sys.log("Received: " + data);
     
     try {

--- a/lib/juggernaut/redis.js
+++ b/lib/juggernaut/redis.js
@@ -1,5 +1,5 @@
 var url     = require("url");
-var redis   = require("redis-client");
+var redis   = require("redis");
 
 module.exports.createClient = function(){
   if (process.env.REDISTOGO_URL) {


### PR DESCRIPTION
Hi,
  Since redis-client is deprecated and doesn't work with node >= 0.3, I've replaced it as a
  requirement with node-redis.

  I've tested it on node 0.3.8 and 0.4.2 and it works fine.
