### PR TITLE
Prevent subscribe callbacks from piling up when resubscribing

### DIFF
--- a/public/juggernaut.js
+++ b/public/juggernaut.js
@@ -89,6 +89,8 @@ Juggernaut.fn.unsubscribe = function(channel) {
   message.channel = channel;
 
   this.write(message);
+
+  delete this.handlers[channel + ":data"];
 };
 
 // Private


### PR DESCRIPTION
I found an issue with unsubscribe where it never kills the callback it sets up on subscribe. If you subscribe to a channel, unsubscribe, and then subscribe again, you end up with two instances of the callback listening for events. They continue to pile up the more you do this (switching between channels in a chatroom, for example). The way I solved this is by deleting the handler for the channel on unsubscribe.

There may be a better way, but this worked for me :)
