### PR TITLE
Fixed "undefined local variable or method `redis_options' for Juggernaut:Module (NameError)"

### DIFF
--- a/client/lib/juggernaut.rb
+++ b/client/lib/juggernaut.rb
@@ -26,7 +26,7 @@ module Juggernaut
   end
   
   def subscribe
-    Redis.new(redis_options).subscribe(*EVENTS) do |on|
+    Redis.new(options).subscribe(*EVENTS) do |on|
       on.message do |type, msg|
         yield(type.gsub(/^juggernaut:/, "").to_sym, JSON.parse(msg))
       end


### PR DESCRIPTION
Fixed juggernaut-2.0.2/lib/juggernaut.rb:29:in `subscribe': undefined local variable or method`redis_options' for Juggernaut:Module (NameError).

2.0.2 is currently broken. Could you apply this and release a new version?
