### PR TITLE
The RedisToGo fix was only accounting for heroku namespaces.

### DIFF
--- a/lib/juggernaut/redis.js
+++ b/lib/juggernaut/redis.js
@@ -8,7 +8,7 @@ module.exports.createClient = function(){
   if (process.env.REDISTOGO_URL) {
     var address = url.parse(process.env.REDISTOGO_URL);
     client = redis.createClient(address.port, address.hostname);
-    client.auth(address.auth.replace("redistogo:", ""));
+    client.auth(address.auth.split(":")[1]);
   } else {
     client = redis.createClient();
   }


### PR DESCRIPTION
This fixes a bug in redistogo authentication to work from outside of heroku as well.

When you use a stock redistogo database without heroku, the name space looks like:

username:password

Not just:

redistogo:password.
