### PR TITLE
Added support for Redis host and port arguments

### DIFF
--- a/lib/juggernaut/channel.js
+++ b/lib/juggernaut/channel.js
@@ -6,6 +6,10 @@ Channel = module.exports = require("./klass").create();
 Channel.extend({
   channels: {},
   
+  initEventsClient: function(redisPort, redisHost) {
+    Events.initEvents(redisPort, redisHost);
+  },
+  
   find: function(name){
     if ( !this.channels[name] ) 
       this.channels[name] = Channel.inst(name)

--- a/lib/juggernaut/client.js
+++ b/lib/juggernaut/client.js
@@ -5,7 +5,8 @@ var Events  = require("./events");
 Client = module.exports = require("./klass").create();
 
 Client.include({
-  init: function(conn){
+  init: function(conn, redisPort, redisHost){
+    Events.initClient(redisPort, redisHost);
     this.connection = conn;
     this.session_id = this.connection.session_id;
   },

--- a/lib/juggernaut/connection.js
+++ b/lib/juggernaut/connection.js
@@ -3,10 +3,10 @@ var Client = require("./client");
 Connection = module.exports = require("./klass").create();
 
 Connection.include({
-  init: function(stream){
+  init: function(stream, redisPort, redisHost){
     this.stream     = stream;
     this.session_id = this.stream.id;
-    this.client     = Client.inst(this);
+    this.client     = Client.inst(this, redisPort, redisHost);
 
     this.stream.on("message", this.proxy(this.onmessage));
     this.stream.on("disconnect", this.proxy(this.ondisconnect));

--- a/lib/juggernaut/events.js
+++ b/lib/juggernaut/events.js
@@ -1,12 +1,14 @@
 var redis   = require("./redis");
 
 Events = module.exports = {};
+Events.client = null;
 
 Events.initEvents = function(redisPort, redisHost) {
   this.initClient(redisPort, redisHost);
 };
 
 Events.initClient = function(redisPort, redisHost) {
+  if (this.client) return;
   this.client = redis.createClient(redisPort, redisHost);
 };
 

--- a/lib/juggernaut/events.js
+++ b/lib/juggernaut/events.js
@@ -2,7 +2,13 @@ var redis   = require("./redis");
 
 Events = module.exports = {};
 
-Events.client = redis.createClient();
+Events.initEvents = function(redisPort, redisHost) {
+  this.initClient(redisPort, redisHost);
+};
+
+Events.initClient = function(redisPort, redisHost) {
+  this.client = redis.createClient(redisPort, redisHost);
+};
 
 Events.publish = function(key, value){
   this.client.publish(

--- a/lib/juggernaut/index.js
+++ b/lib/juggernaut/index.js
@@ -3,8 +3,11 @@ require("./ext/array");
 var Publish = require("./publish");
 var Server  = require("./server");
 
-module.exports.listen = function(port){
-  Publish.listen();
-  var server = Server.inst();
-  server.listen(port);
+module.exports.listen = function(nodePort, redisPort, redisHost){
+  var redisPort = (redisPort || "6379");
+  var redisHost = (redisHost || "127.0.0.1");
+  
+  Publish.listen(redisPort, redisHost);
+  var server = Server.inst(redisPort, redisHost);
+  server.listen(nodePort);
 };

--- a/lib/juggernaut/publish.js
+++ b/lib/juggernaut/publish.js
@@ -4,8 +4,8 @@ var Message = require("./message");
 var Channel = require("./channel");
 
 Publish = module.exports = {};
-Publish.listen = function(){
-  this.client = redis.createClient();
+Publish.listen = function(redisPort, redisHost){
+  this.client = redis.createClient(redisPort, redisHost);
   
   this.client.on("message", function(_, data) {
     util.log("Received: " + data);

--- a/lib/juggernaut/publish.js
+++ b/lib/juggernaut/publish.js
@@ -17,5 +17,6 @@ Publish.listen = function(redisPort, redisHost){
     Channel.publish(message);
   });
   
+  Channel.initEventsClient(redisPort, redisHost);
   this.client.subscribe("juggernaut");
 };

--- a/lib/juggernaut/redis.js
+++ b/lib/juggernaut/redis.js
@@ -2,7 +2,7 @@ var util   = require("util");
 var url   = require("url");
 var redis = require("redis");
 
-module.exports.createClient = function(){
+module.exports.createClient = function(redisPort, redisHost){
   var client;
   
   if (process.env.REDISTOGO_URL) {
@@ -10,7 +10,7 @@ module.exports.createClient = function(){
     client = redis.createClient(address.port, address.hostname);
     client.auth(address.auth.split(":")[1]);
   } else {
-    client = redis.createClient();
+    client = redis.createClient(redisPort, redisHost);
   }
   
   // Prevent redis calling exit

--- a/lib/juggernaut/server.js
+++ b/lib/juggernaut/server.js
@@ -20,7 +20,7 @@ Server = module.exports = require("./klass").create();
 var fileServer = new nstatic.Server(path.normalize(__dirname + "../../../public"));
 
 Server.include({
-  init: function(){
+  init: function(redisPort, redisHost){
     var connectionListener = function(request, response){
       request.addListener("end", function() {
 
@@ -44,7 +44,7 @@ Server.include({
     }
 
     this.io = io.listen(this.httpServer);
-    this.io.sockets.on("connection", function(stream){ Connection.inst(stream) });
+    this.io.sockets.on("connection", function(stream){ Connection.inst(stream, redisPort, redisHost) });
   },
 
   listen: function(port){

--- a/server.js
+++ b/server.js
@@ -8,7 +8,9 @@ var help = [
     "Starts a juggernaut server using the specified command-line options",
     "",
     "options:",
-    "  --port   PORT       Port that the proxy server should run on",
+    "  --port      PORT    Port that the proxy server should run on",
+    "  --redisport PORT    Port for redis server",
+    "  --redishost HOST    Host for redis server",
     "  --silent            Silence the log output",
     "  -h, --help          You're staring at it"
 ].join('\n');
@@ -18,4 +20,4 @@ if (argv.h || argv.help) {
 }
 
 Juggernaut = require("./index");
-Juggernaut.listen(argv.port);
+Juggernaut.listen(argv.port, argv.redisport, argv.redishost);


### PR DESCRIPTION
Updated server.js to accept --redisport and --redishost arguments.

Values are passed to listen(), and normalized to defaults. From here forwarded along through the application.

A minor 'refactorish' change: Events.client is no longer created inline. Instead publish inits channel which inits event with proper redis information.
## 

We're using this in production today. I'm interested in feedback/drawbacks of the implementation. I have another patch that allows the use of Redis.namespace for namespaced redis instances.
